### PR TITLE
Prevent Psalm TypeParseTreeException:

### DIFF
--- a/connect/SFtpManager.php
+++ b/connect/SFtpManager.php
@@ -9,7 +9,7 @@ define('NET_SFTP_LOGGING', 'NET_SFTP_LOG_COMPLEX');
 
 /**
  * Class SFtpManager
- * @mixin SFTP;
+ * @mixin SFTP
  * @package Apolon
  */
 class SFtpManager extends Component


### PR DESCRIPTION
During ./vendor/bin/psalm --init, psalm throws an exception.
This is caused by the semicolon in the @mixin tag.